### PR TITLE
Update ci cd scripts to latest versions

### DIFF
--- a/.github/workflows/code-checks.yaml
+++ b/.github/workflows/code-checks.yaml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v4
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v4
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v4

--- a/.github/workflows/code-checks.yaml
+++ b/.github/workflows/code-checks.yaml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
+          cache: poetry
 
       - name: Install dependencies
         run: poetry install
@@ -42,6 +43,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
+          cache: poetry
 
       - name: Install dependencies
         run: poetry install
@@ -63,6 +65,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
+          cache: poetry
 
       - name: Install dependencies
         run: poetry install

--- a/.github/workflows/code-checks.yaml
+++ b/.github/workflows/code-checks.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.12
 
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.12
 
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.12
 

--- a/.github/workflows/code-checks.yaml
+++ b/.github/workflows/code-checks.yaml
@@ -14,13 +14,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Setup Poetry
+        run: pipx install poetry
+
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
-
-      - name: Install Poetry
-        run: curl -sSL https://install.python-poetry.org | python3 -
 
       - name: Install dependencies
         run: poetry install
@@ -35,13 +35,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Setup Poetry
+        run: pipx install poetry
+
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
-
-      - name: Install Poetry
-        run: curl -sSL https://install.python-poetry.org | python3 -
 
       - name: Install dependencies
         run: poetry install
@@ -56,13 +56,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Setup Poetry
+        run: pipx install poetry
+
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
-
-      - name: Install Poetry
-        run: curl -sSL https://install.python-poetry.org | python3 -
 
       - name: Install dependencies
         run: poetry install


### PR DESCRIPTION
This PR updates the various GitHub action scripts that are imported to the latest versions (e.g. actions/checkout to v4 and actions/setup-python to v5).

It also includes a few updates to the script to make it align with the GitHub documentation for the new action versions.